### PR TITLE
make the crate a no_std module

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,3 +1,6 @@
+use alloc::{format, vec};
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 
 use crate::Millisecond;
@@ -88,7 +91,7 @@ impl MillisecondPart {
 }
 
 impl Display for MillisecondPart {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.to_short_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 //! [docs-rs]: https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs
 //!
 //! A better way to format and display time. This crate converts 33023448000 to 1y 17d 5h 10m 48s
+
+#![no_std]
+extern crate alloc;
+
 pub use formatter::MillisecondPart;
 pub use splitter::Millisecond;
 

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt::{Display, Formatter};
 
 use crate::formatter::MillisecondPart;
@@ -252,7 +254,7 @@ impl Millisecond {
     }
 }
 impl Display for Millisecond {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.to_short_string())
     }
 }


### PR DESCRIPTION
The crate does not rely on any platform so it should be a no_std crate to widen its usage in different environments.