### PR TITLE
(feat) add dominant option in a patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "millisecond"
-version = "0.4.0"
+version = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "millisecond"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Morteza Raeisi<raeisimv@outlook.com>"]
 repository = "https://github.com/raeisimv/millisecond.git"

--- a/readme.md
+++ b/readme.md
@@ -32,12 +32,15 @@ fn main() {
 ## Options
 Customize the parser and the output format using the `MillisecondOption` struct.
 
-| Option | Description |
-| :---: | :---: |
-| `long` | When enabled, uses full and descriptive labels for time units, such as `years` instead of abbreviated forms like `y`. |
-| `days_instead_of_years` | When activated, displays time durations in days rather than converting them into years. |
+| Option | Description | Example |
+| :--- | :--- | :--- |
+| `long` | uses full and descriptive labels for time units, such as `years` instead of abbreviated forms like `y`. | `2y` -> `2 years` |
+| `dominant_only` | displays the most dominant part only (the most left part). | `1y 2d` -> `1y` |
+| `days_instead_of_years` | displays time durations in days rather than converting them into years. | `1y 1d` -> `366d` |
 
-### Option creating shorthand
+*All options have deafult value unless specified*
+
+### Options shorthand
 In order to easily create a `MillisecondOption` instance, you can use the `MillisecondOption::default()` method:
 ```rust
 let option = MillisecondOption{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,6 +40,9 @@ pub struct MillisecondOption {
 
     /// When activated, displays time durations in days rather than converting them into years.
     pub days_instead_of_years: bool,
+
+    /// When activated, displays the most dominant part only (the most left part).
+    pub dominant_only: bool,
 }
 
 impl MillisecondOption {
@@ -226,9 +229,22 @@ impl MillisecondPart {
 }
 
 pub fn ms_parts_to_string(parts: &[Option<MillisecondPart>; 8], opt: &MillisecondOption) -> String {
+    let take = if opt.dominant_only {
+        1
+    } else {
+        8 // or infinity
+    };
     parts
         .iter()
+        .skip_while(|x| {
+            if opt.dominant_only {
+                x.is_none()
+            } else {
+                false
+            }
+        })
         .filter(|x| x.is_some())
+        .take(take)
         .map(|x| x.unwrap().get_label(opt.long))
         .collect::<Vec<_>>()
         .join(" ")
@@ -556,5 +572,46 @@ mod tests {
             let act = ms_parts_to_string(&parse_duration(test, &opt), &opt);
             assert_eq!(&act, exp);
         }
+    }
+    #[test]
+    fn should_display_dominant_part_only() {
+        #[allow(clippy::identity_op)]
+        let test_cases = [
+            (Duration::from_secs((365 + 0) * 24 * 60 * 60), "1y"),
+            (Duration::from_secs((365 + 1) * 24 * 60 * 60), "1y"),
+            (Duration::from_secs((24 + 0) * 60 * 60), "1d"),
+            (Duration::from_secs((24 + 1) * 60 * 60), "1d"),
+            (Duration::from_secs((60 + 0) * 60), "1h"),
+            (Duration::from_secs((60 + 1) * 60), "1h"),
+            (
+                Duration::from_secs((365 * 24 * 60 * 60) + (23 * 60 * 60)),
+                "1y",
+            ),
+            (Duration::from_millis(2_100), "2s"),
+            (Duration::from_millis(100), "100ms"),
+        ];
+
+        for (test, exp) in test_cases.iter() {
+            let opt = MillisecondOption {
+                dominant_only: true,
+                ..MillisecondOption::default()
+            };
+
+            let act = ms_parts_to_string(&parse_duration(test, &opt), &opt);
+            assert_eq!(&act, exp);
+        }
+
+        let opt = MillisecondOption {
+            dominant_only: true,
+            days_instead_of_years: true,
+            ..MillisecondOption::default()
+        };
+        assert_eq!(
+            "366d",
+            ms_parts_to_string(
+                &parse_duration(&Duration::from_secs((365 + 1) * 24 * 60 * 60), &opt),
+                &opt
+            )
+        );
     }
 }


### PR DESCRIPTION
Implement the `dominant` option to show the dominant part only (the first left-sdie part only)

fixes #2 